### PR TITLE
Added info about RubyGems version restrictions

### DIFF
--- a/documentation/autoproj/advanced/osdeps.md
+++ b/documentation/autoproj/advanced/osdeps.md
@@ -116,6 +116,15 @@ gnuplot:
     debian: gnuplot
 ~~~~~~~~~~~~~~~~~~
 
+In addition to that, RubyGems can be pinned/restricted to certain versions.
+For example, the following snippet would pin 'hoe' to versions below 2.x
+
+~~~~~~~~~~~~~~~~~~
+hoe:
+    gem:
+        hoe<2.0.0
+~~~~~~~~~~~~~~~~~~
+
 Ignoring some dependencies
 --------------------------
 It is possible that, on some operating systems, a given package should simply be


### PR DESCRIPTION
This patch adds some info about how to constrain/restrict the versions of RubyGems using .osdeps files