### PR TITLE
Update bootstrap scripts to new autoproj release (2.17.0)

### DIFF
--- a/downloads/autoproj_bootstrap
+++ b/downloads/autoproj_bootstrap
@@ -760,7 +760,11 @@ require 'bundler/setup'
             end
 
             def self.default_bundler_version
-                "2.3.6" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
+                if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
+                    "2.3.6"
+                elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0.0")
+                    "2.4.22"
+                end
             end
 
             def save_config

--- a/downloads/autoproj_bootstrap-dev
+++ b/downloads/autoproj_bootstrap-dev
@@ -97,7 +97,9 @@ module Autoproj
                 @ruby_executable = config["ruby_executable"]
                 @local = false
 
-                install_gems_in_gem_user_dir unless @gems_install_path
+                @gems_install_path ||= default_gems_install_path
+                @gems_install_path = File.expand_path(@gems_install_path)
+
                 env["GEM_HOME"] = [gems_gem_home]
                 env["GEM_PATH"] = [gems_gem_home]
             end
@@ -171,24 +173,17 @@ module Autoproj
             # (see #local?)
             attr_writer :local
 
-            # The user-wide place where RubyGems installs gems
-            def self.dot_gem_dir
-                if Gem.respond_to?(:data_home) # Debian 11+
-                    File.join(Gem.data_home, "gem")
-                else
-                    File.join(Gem.user_home, ".gem")
-                end
-            end
-
-            # The version and platform-specific suffix under {#dot_gem_dir}
+            # The version and platform-specific suffix
             #
             # This is also the suffix used by bundler to install gems
             def self.gems_path_suffix
-                @gems_path_suffix ||=
-                    Pathname
-                    .new(Gem.user_dir)
-                    .relative_path_from(Pathname.new(dot_gem_dir))
-                    .to_s
+                return @gems_path_suffix if @gem_path_suffix
+
+                parts = [Gem.ruby_engine]
+                unless RbConfig::CONFIG["ruby_version"].empty?
+                    parts << RbConfig::CONFIG["ruby_version"]
+                end
+                @gems_path_suffix = File.join parts
             end
 
             # The path into which the workspace's gems should be installed
@@ -219,21 +214,21 @@ module Autoproj
                 end
             end
 
-            # Install autoproj in Gem's default user dir
-            def install_gems_in_gem_user_dir
+            # Get autoproj's default path for installing gems
+            def default_gems_install_path
                 xdg_default_gem_path = xdg_var("XDG_DATA_HOME",
                                                File.join(Dir.home, ".local", "share", "autoproj", "gems"))
                 default_gem_path = File.join(
                     Dir.home, ".autoproj", "gems"
                 )
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+
+                if File.directory?(xdg_default_gem_path)
+                    xdg_default_gem_path
+                elsif File.directory?(default_gem_path)
+                    default_gem_path
+                else
+                    xdg_default_gem_path
+                end
             end
 
             # Whether autoproj should prefer OS-independent packages over their
@@ -298,11 +293,12 @@ module Autoproj
                         @gem_source = url
                     end
                     opt.on "--gems-path=PATH", "install gems under this path instead "\
-                                               "of ~/.autoproj/gems" do |path|
-                        self.gems_install_path = path
+                                               "of #{default_gems_install_path} (do not use with --public-gems)" do |path|
+                        @gems_install_path = path
                     end
-                    opt.on "--public-gems", "install gems in the default gem location" do
-                        install_gems_in_gem_user_dir
+                    opt.on "--public-gems", "install gems in the default gem location: #{default_gems_install_path}"\
+                                            " (do not use with --gems-path)" do
+                        @gems_install_path = default_gems_install_path
                     end
                     opt.on "--bundler-version=VERSION_CONSTRAINT", String, "use the provided "\
                                                                            "string as a version constraint for bundler" do |version|
@@ -324,6 +320,7 @@ module Autoproj
                            "when reinstalling an existing autoproj workspace, do not "\
                            "use the config in .autoproj/ as seed" do
                         @config.clear
+                        @config["bundler_version"] = Install.default_bundler_version
                     end
                     opt.on "--seed-config=PATH", String, "path to a seed file that "\
                                                          "should be used to initialize the configuration" do |path|
@@ -757,8 +754,18 @@ require 'bundler/setup'
                 end
 
                 @config = config
+                @config["bundler_version"] ||= self.class.default_bundler_version
+
                 %w[gems_install_path prefer_indep_over_os_packages].each do |flag|
                     instance_variable_set "@#{flag}", config.fetch(flag, false)
+                end
+            end
+
+            def self.default_bundler_version
+                if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
+                    "2.3.6"
+                elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0.0")
+                    "2.4.22"
                 end
             end
 


### PR DESCRIPTION
Scripts have changed with new release: https://github.com/rock-core/autoproj/releases/tag/v2.17.0

Related issue: https://github.com/rock-core/rock-core.github.io/issues/8