### PR TITLE
Add `--dev` option to replace otherwise identical bootstrap-dev

### DIFF
--- a/downloads/autoproj_bootstrap
+++ b/downloads/autoproj_bootstrap
@@ -272,6 +272,19 @@ module Autoproj
                  "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
+            # The content of the {#gemfile} that installs autoproj and
+            # autobuild from their master branches on GitHub, for development
+            # purposes
+            #
+            # @return [String]
+            def dev_gemfile_contents
+                ["source \"#{gem_source}\"",
+                 "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
+                 "gem \"autoproj\", git: \"https://github.com/rock-core/autoproj.git\", branch: \"master\"",
+                 "gem \"autobuild\", git: \"https://github.com/rock-core/autobuild.git\", branch: \"master\"",
+                 "gem \"utilrb\", \">= 3.0.1\""].join("\n")
+            end
+
             def load_yaml(contents)
                 if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.1.0")
                     YAML.safe_load(contents, permitted_classes: [Symbol])
@@ -317,6 +330,13 @@ module Autoproj
                         raise "cannot give both --version and --gemfile" if @gemfile
 
                         @gemfile = default_gemfile_contents(version)
+                    end
+                    opt.on "--dev", "install autoproj and autobuild from their "\
+                                    "master branches on GitHub instead of "\
+                                    "released gems" do
+                        raise "cannot give both --dev and --gemfile/--version" if @gemfile
+
+                        @gemfile = dev_gemfile_contents
                     end
                     opt.on "--gemfile=PATH", String, "use the given Gemfile to install "\
                                                      "autoproj instead of the default" do |path|


### PR DESCRIPTION
Additionally, the `...-dev` script could be deleted or replaced to output a warning.
Instead of a `--dev` option, we could also have that behavior when passing `--version="master"`.
The `utilrb` constraint is likely not necessary anymore, right?


Same changes need to be pushed to https://github.com/rock-core/autoproj/tree/master/bin

Also: I guess we should remove the `downloads/stable` subfolder and adapt the `boostrap-dev.sh` script (if that is actually needed)
